### PR TITLE
Make history back button work properly

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,7 +6,7 @@ function onTabUpdate(tabID, changeInfo, tabInfo) {
   if (!id.startsWith('/shorts/')) { return; }
   id = id.substring(8); // 8 === '/shorts/'.length
 
-  browser.tabs.update(tabID, {url: `${url.protocol}//${url.hostname}/watch?v=${id}`});
+  browser.tabs.update(tabID, {loadReplace: true, url: `${url.protocol}//${url.hostname}/watch?v=${id}`});
 }
 
 async function main() {


### PR DESCRIPTION
Bug: The Back button does not work.

## Steps to reproduce

1. Find a link to a yt-short.
2. Click it.
3. Try to use the "History back button" of your browser.

## What happened

After pressing back you'll end up on the shorts interface, which causes a redirect to the non-shorts version.
Keep clicking the back button and you're in an endless loop.

## What should happen

* Back button should bring you back to the site the yt-shorts link was originally on.

## How to fix

Simply set the history replace flag on the tab.update call.